### PR TITLE
Add is result ready route

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,13 @@ RUN add-apt-repository -y ppa:deadsnakes \
 RUN python3.11 -m venv /venv
 ENV PATH=/venv/bin:$PATH
 
-# move files to dir
-COPY . /app
 WORKDIR /app
+COPY ./requirements.txt /app/requirements.txt
 
 RUN pip install wheel
 RUN pip install -r requirements.txt
+
+# move files to dir
+COPY . /app
 
 CMD ["bash", "entrypoint.sh"]


### PR DESCRIPTION
new route /tasks(<task_id>/status

returns {
        "status": state
    }

state can be
*PENDING*
        The task is waiting for execution. Or task doesnt exist ;) see: https://github.com/celery/celery/issues/3596
    *STARTED*
        The task has been started.
    *RETRY*
        The task is to be retried, possibly because of failure.
    *FAILURE: <Exception>*
        The task raised an exception, or has exceeded the retry limit.
    *SUCCESS*
        The task executed successfully.  The :attr:`result` attribute
        then contains the tasks return value.